### PR TITLE
feat: GitHub integration with OAuth Device Flow

### DIFF
--- a/specs/components/github-connect.spec.md
+++ b/specs/components/github-connect.spec.md
@@ -1,6 +1,6 @@
 ---
 module: github-connect
-version: 1
+version: 2
 status: active
 files:
   - src/app/components/github-connect/github-connect.ts
@@ -8,13 +8,14 @@ files:
   - src/app/components/github-connect/github-connect.scss
 depends_on:
   - github-service
+  - github-oauth
 ---
 
 # GitHub Connect
 
 ## Purpose
 
-Sidebar component for configuring and managing the GitHub connection. Provides a form to enter PAT, owner, repo, branch, and specs path. Once connected, displays the connection status and offers "Pull Specs" and "Disconnect" actions. Emits pulled specs to the parent component for import into the local store.
+Sidebar component for configuring and managing the GitHub connection. Supports two authentication modes: **OAuth Device Flow** (primary, one-click "Sign in with GitHub") and **Personal Access Token** (fallback). Once authenticated, displays a repo configuration form. Once connected to a repo, displays the connection status and offers "Pull Specs" and "Disconnect" actions. Emits pulled specs to the parent component for import into the local store.
 
 ## Public API
 
@@ -34,29 +35,51 @@ Sidebar component for configuring and managing the GitHub connection. Provides a
 
 | Method | Parameters | Returns | Description |
 |--------|-----------|---------|-------------|
-| `toggleForm` | `()` | `void` | Toggles visibility of the connection form |
-| `onConnect` | `()` | `Promise<void>` | Builds config from form fields and calls `github.connect()` |
-| `onDisconnect` | `()` | `void` | Disconnects and hides the form |
+| `toggleForm` | `()` | `void` | Toggles visibility of the repo configuration form |
+| `togglePat` | `()` | `void` | Toggles the PAT form and sets connect mode to `pat` |
+| `onSignIn` | `()` | `Promise<void>` | Initiates GitHub OAuth Device Flow via `GitHubOAuthService` |
+| `onCancelFlow` | `()` | `void` | Cancels an in-progress device flow |
+| `onSignOut` | `()` | `void` | Signs out of OAuth, disconnects from repo |
+| `onConnect` | `()` | `Promise<void>` | Connects to repo using OAuth token or PAT depending on auth state |
+| `onDisconnect` | `()` | `void` | Disconnects from repo and hides the form |
 | `onPull` | `()` | `Promise<void>` | Pulls all specs and emits via `specsPulled` output |
+| `copyCode` | `()` | `Promise<void>` | Copies the device flow user code to clipboard |
 | `updateField` | `(field, event)` | `void` | Updates a form field signal from an input event |
 
 ## Invariants
 
-1. The form is hidden by default and toggled with the "Connect GitHub" button
-2. When connected, the form is replaced by connection info showing `owner/repo`
-3. The "Connect" button is disabled when token, owner, or repo fields are empty
-4. The "Pull Specs" button is disabled while loading
-5. Error messages from the GitHub service are displayed in the form area
-6. Token field uses `type="password"` to mask the PAT
-7. Default values: branch is `main`, specsPath is `specs`
+1. When `GITHUB_CLIENT_ID` is configured, a "Sign in with GitHub" button is shown as the primary auth method
+2. A "Use Personal Access Token" button is always available as a fallback
+3. During the device flow, the user code is displayed with a "Copy" button and a link to GitHub's verification page opens automatically
+4. Once authenticated via OAuth, the user's avatar and username are displayed
+5. After OAuth sign-in, a "Connect Repo" button reveals the repo configuration form (owner, repo, branch, specsPath — no token field)
+6. In PAT mode, the full form includes the token field
+7. When connected to a repo, the form is replaced by connection info showing `owner/repo` with "Pull Specs", "Disconnect", and (if OAuth) "Sign Out" buttons
+8. The "Connect" button is disabled when required fields are empty
+9. The "Pull Specs" button is disabled while loading
+10. Error messages from both `GitHubService` and `GitHubOAuthService` are displayed in `.form-error`
+11. Default values: branch is `main`, specsPath is `specs`
 
 ## Behavioral Examples
 
-### Scenario: Open connection form and connect
+### Scenario: Sign in with GitHub OAuth
 
-- **Given** user is not connected
-- **When** user clicks "Connect GitHub", fills in token/owner/repo, and clicks "Connect"
-- **Then** `GitHubService.connect()` is called, and on success the form is replaced with connection status
+- **Given** user is not authenticated and `GITHUB_CLIENT_ID` is configured
+- **When** user clicks "Sign in with GitHub"
+- **Then** the device flow starts, a user code is displayed, GitHub verification page opens in a new tab, and the component shows "Waiting for authorization..."
+- **And** once the user authorizes on GitHub, the component shows the user's avatar/username and a "Connect Repo" button
+
+### Scenario: Connect repo after OAuth sign-in
+
+- **Given** user is authenticated via OAuth but not connected to a repo
+- **When** user clicks "Connect Repo", fills in owner/repo, and clicks "Connect"
+- **Then** `GitHubService.connectWithOAuth()` is called using the OAuth token, and on success the component shows the connected state
+
+### Scenario: Fall back to PAT
+
+- **Given** user is not authenticated
+- **When** user clicks "Use Personal Access Token", fills in token/owner/repo, and clicks "Connect"
+- **Then** `GitHubService.connect()` is called with the PAT, and on success the form is replaced with connection status
 
 ### Scenario: Pull specs from connected repo
 
@@ -64,17 +87,26 @@ Sidebar component for configuring and managing the GitHub connection. Provides a
 - **When** user clicks "Pull Specs"
 - **Then** all `.spec.md` files are fetched and emitted via `specsPulled`
 
-### Scenario: Disconnect
+### Scenario: Disconnect from repo
 
 - **Given** user is connected
 - **When** user clicks "Disconnect"
-- **Then** `GitHubService.disconnect()` is called and the component reverts to showing the "Connect GitHub" button
+- **Then** `GitHubService.disconnect()` is called, component reverts to showing the auth buttons (OAuth session persists)
+
+### Scenario: Sign out completely
+
+- **Given** user is authenticated via OAuth and connected to a repo
+- **When** user clicks "Sign Out"
+- **Then** both `GitHubService.disconnect()` and `GitHubOAuthService.signOut()` are called, component reverts to initial state
 
 ## Error Cases
 
 | Condition | Behavior |
 |-----------|----------|
 | Connection fails (bad token/repo) | Error message from GitHub service displayed in `.form-error` |
+| OAuth device flow error | Error from `GitHubOAuthService` displayed in `.form-error` |
+| Device code expires | Error message shown, user can retry |
+| User denies OAuth authorization | Error message "Authorization was denied" shown |
 | Pull fails (network/API error) | Error propagates to GitHub service's error signal |
 | Form submitted with empty required fields | Connect button is disabled, no API call made |
 
@@ -84,7 +116,9 @@ Sidebar component for configuring and managing the GitHub connection. Provides a
 
 | Module | What is used |
 |--------|-------------|
-| `github-service` | `connect`, `disconnect`, `pullSpecs`, `connected`, `loading`, `error`, `config` signals |
+| `github-service` | `connect`, `connectWithOAuth`, `disconnect`, `pullSpecs`, `connected`, `loading`, `error`, `config` signals |
+| `github-oauth` | `startDeviceFlow`, `cancelFlow`, `signOut`, `state`, `userCode`, `verificationUri`, `authenticated`, `username`, `avatarUrl`, `error` signals |
+| `environment` | `GITHUB_CLIENT_ID` to determine if OAuth is available |
 
 ### Consumed By
 
@@ -97,3 +131,4 @@ Sidebar component for configuring and managing the GitHub connection. Provides a
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-02-24 | CorvidAgent | Initial spec — GitHub connect sidebar component |
+| 2026-02-24 | CorvidAgent | Add OAuth Device Flow support as primary auth, PAT as fallback |

--- a/specs/services/github-oauth.spec.md
+++ b/specs/services/github-oauth.spec.md
@@ -1,0 +1,143 @@
+---
+module: github-oauth
+version: 1
+status: active
+files:
+  - src/app/services/github-oauth.service.ts
+depends_on:
+  - github-service
+---
+
+# GitHub OAuth Service
+
+## Purpose
+
+Implements the GitHub OAuth Device Flow (RFC 8628) for Specl, enabling users to authenticate with GitHub without entering a personal access token (PAT). This is a client-only flow requiring no backend server — the user clicks "Sign in with GitHub," receives a one-time code, authorizes on GitHub's website, and the app automatically detects authorization and stores the access token. The service manages the full device flow lifecycle: initiation, polling, token storage, and sign-out.
+
+## Public API
+
+### Exported Types
+
+| Type | Description |
+|------|-------------|
+| `OAuthState` | Union: `'idle' \| 'awaiting_code' \| 'polling' \| 'authenticated' \| 'error'` |
+| `DeviceCodeResponse` | Device code response from GitHub: `device_code`, `user_code`, `verification_uri`, `expires_in`, `interval` |
+
+### Exported Classes
+
+| Class | Description |
+|-------|-------------|
+| `GitHubOAuthService` | Angular injectable service implementing the GitHub Device Flow |
+
+#### Signals (Readonly)
+
+| Signal | Type | Description |
+|--------|------|-------------|
+| `state` | `Signal<OAuthState>` | Current state of the OAuth flow |
+| `userCode` | `Signal<string \| null>` | The user code to display during device flow, null when not in flow |
+| `verificationUri` | `Signal<string \| null>` | The URI where user enters the code |
+| `accessToken` | `Signal<string \| null>` | The OAuth access token, null if not authenticated |
+| `username` | `Signal<string \| null>` | GitHub username of the authenticated user |
+| `avatarUrl` | `Signal<string \| null>` | GitHub avatar URL of the authenticated user |
+| `error` | `Signal<string \| null>` | Error message, null if no error |
+| `authenticated` | `Signal<boolean>` | Computed: true when accessToken is non-null |
+
+#### Methods
+
+| Method | Parameters | Returns | Description |
+|--------|-----------|---------|-------------|
+| `startDeviceFlow` | `()` | `Promise<void>` | Initiates the device flow: requests a device code, then begins polling |
+| `cancelFlow` | `()` | `void` | Cancels an in-progress device flow and resets to idle |
+| `signOut` | `()` | `void` | Clears the stored access token, username, avatar, and resets to idle |
+
+## Invariants
+
+1. The GitHub OAuth App Client ID is configured via `environment.ts` as `GITHUB_CLIENT_ID`
+2. Device flow requests go to `https://github.com/login/device/code` with `Accept: application/json`
+3. Token polling requests go to `https://github.com/login/oauth/access_token` with `Accept: application/json`
+4. Polling interval respects the `interval` value from the device code response (typically 5 seconds)
+5. Polling stops when: token is granted, user denies, code expires, or flow is cancelled
+6. Access token is stored in `localStorage` under key `specl:github-oauth-token`
+7. Username and avatar URL are stored in `localStorage` under `specl:github-oauth-user`
+8. On construction, the service restores token and user info from localStorage and sets `authenticated` if a token exists
+9. After obtaining a token, the service fetches `/user` from the GitHub API to get the username and avatar
+10. Requested scopes: `repo` (for read/write access to repositories)
+11. `startDeviceFlow()` transitions state: `idle` → `awaiting_code` → `polling` → `authenticated`
+12. If GitHub returns `slow_down` during polling, the interval is increased by 5 seconds
+13. CORS proxy: GitHub's OAuth endpoints do not support CORS. Requests are proxied through `https://corsproxy.io/?url=` prefix
+14. `cancelFlow()` aborts any in-progress polling and resets state to `idle`
+
+## Behavioral Examples
+
+### Scenario: Successful device flow authentication
+
+- **Given** the service is in `idle` state
+- **When** `startDeviceFlow()` is called
+- **Then** state becomes `awaiting_code`, `userCode` and `verificationUri` are populated
+- **And** state becomes `polling` while waiting for user to authorize
+- **And** once authorized, state becomes `authenticated`, `accessToken` is set, user info is fetched
+
+### Scenario: User denies authorization
+
+- **Given** the service is polling for authorization
+- **When** the user clicks "Cancel" on GitHub's device authorization page
+- **Then** polling receives `access_denied` error, state becomes `error`, error message is set
+
+### Scenario: Device code expires
+
+- **Given** the service is polling and the code expires (default 15 minutes)
+- **When** the next poll response returns `expired_token`
+- **Then** state becomes `error` with message about expiration
+
+### Scenario: Cancel flow
+
+- **Given** the service is in `polling` state
+- **When** `cancelFlow()` is called
+- **Then** polling stops, state resets to `idle`, userCode and verificationUri are cleared
+
+### Scenario: Restore session on startup
+
+- **Given** localStorage contains a valid OAuth token and user info
+- **When** the service is constructed
+- **Then** `accessToken`, `username`, and `avatarUrl` are restored, state is `authenticated`
+
+### Scenario: Sign out
+
+- **Given** the service is in `authenticated` state
+- **When** `signOut()` is called
+- **Then** token and user info are cleared from memory and localStorage, state becomes `idle`
+
+## Error Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| Device code request fails (network) | State set to `error`, error message from exception |
+| GitHub returns `access_denied` | State set to `error`, message: "Authorization was denied" |
+| GitHub returns `expired_token` | State set to `error`, message: "Device code expired — please try again" |
+| Token polling network failure | Retries on next interval; gives up after 3 consecutive failures |
+| `/user` fetch fails after token obtained | Token is still stored, username/avatar remain null |
+| No `GITHUB_CLIENT_ID` configured | `startDeviceFlow()` throws: "GitHub OAuth Client ID not configured" |
+
+## Dependencies
+
+### Consumes
+
+| Module | What is used |
+|--------|-------------|
+| GitHub OAuth API (external) | Device code and access token endpoints |
+| GitHub REST API (external) | `/user` endpoint for profile info |
+| `localStorage` (browser) | Token and user info persistence |
+| `environment` | `GITHUB_CLIENT_ID` |
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+| `github-connect` | `startDeviceFlow`, `signOut`, `cancelFlow`, signals for UI state |
+| `github-service` | `accessToken` signal used as auth token when PAT not provided |
+
+## Change Log
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-02-24 | CorvidAgent | Initial spec — GitHub OAuth Device Flow for client-side auth |

--- a/specs/services/github-service.spec.md
+++ b/specs/services/github-service.spec.md
@@ -7,13 +7,14 @@ files:
 depends_on:
   - spec-models
   - spec-store-service
+  - github-oauth
 ---
 
 # GitHub Service
 
 ## Purpose
 
-Provides GitHub API integration for the Specl application, enabling users to connect to a GitHub repository, pull `.spec.md` files, push changes to new branches, and create pull requests. All API calls use the GitHub REST API v3 with a personal access token (PAT) stored in localStorage. This is the bridge between the local IndexedDB spec store and remote GitHub repositories.
+Provides GitHub API integration for the Specl application, enabling users to connect to a GitHub repository, pull `.spec.md` files, push changes to new branches, and create pull requests. All API calls use the GitHub REST API v3 with either a personal access token (PAT) or an OAuth access token from `GitHubOAuthService`. This is the bridge between the local IndexedDB spec store and remote GitHub repositories.
 
 ## Public API
 
@@ -46,6 +47,7 @@ Provides GitHub API integration for the Specl application, enabling users to con
 | Method | Parameters | Returns | Description |
 |--------|-----------|---------|-------------|
 | `connect` | `(config: GitHubConfig)` | `Promise<boolean>` | Tests connection by fetching repo metadata, saves config to localStorage on success |
+| `connectWithOAuth` | `(repoConfig: Omit<GitHubConfig, 'token'>)` | `Promise<boolean>` | Connects using the OAuth token from `GitHubOAuthService` instead of a PAT |
 | `disconnect` | `()` | `void` | Clears config, connection state, and localStorage |
 | `listSpecFiles` | `()` | `Promise<GitHubRepoFile[]>` | Lists `.spec.md` files and directories in the configured specs path |
 | `listAllSpecFiles` | `()` | `Promise<GitHubRepoFile[]>` | Recursively lists all `.spec.md` files under the specs path |
@@ -61,7 +63,7 @@ Provides GitHub API integration for the Specl application, enabling users to con
 1. Config is persisted to `localStorage` under key `specl:github-config` on successful connect
 2. `connect()` tests the connection by fetching `/repos/{owner}/{repo}` before saving config
 3. `disconnect()` always clears both in-memory state and localStorage
-4. All API requests include `Authorization: Bearer {token}` and `X-GitHub-Api-Version: 2022-11-28` headers
+4. All API requests include `Authorization: Bearer {token}` and `X-GitHub-Api-Version: 2022-11-28` headers; if config has no PAT, the OAuth token from `GitHubOAuthService` is used as fallback
 5. `pullSpecs()` recursively walks the specs directory, only returning files ending in `.spec.md`
 6. `pushSpecsAsPR()` creates a unique branch named `specl/update-{timestamp}` for each PR
 7. File content is Base64-decoded on read and Base64-encoded (with UTF-8 handling) on write
@@ -70,11 +72,17 @@ Provides GitHub API integration for the Specl application, enabling users to con
 
 ## Behavioral Examples
 
-### Scenario: Connect to a GitHub repository
+### Scenario: Connect to a GitHub repository with PAT
 
 - **Given** a valid PAT, owner `CorvidLabs`, repo `corvid-agent`, branch `main`, specsPath `specs`
 - **When** `connect(config)` is called
 - **Then** the service fetches `/repos/CorvidLabs/corvid-agent`, sets `connected` to true, saves config to localStorage
+
+### Scenario: Connect to a GitHub repository with OAuth
+
+- **Given** the user is authenticated via `GitHubOAuthService`
+- **When** `connectWithOAuth({ owner: 'CorvidLabs', repo: 'corvid-agent', branch: 'main', specsPath: 'specs' })` is called
+- **Then** the service uses the OAuth token for the API call, sets `connected` to true on success
 
 ### Scenario: Pull specs from a repository
 
@@ -113,12 +121,13 @@ Provides GitHub API integration for the Specl application, enabling users to con
 |--------|-------------|
 | GitHub REST API (external) | Contents, Git Refs, Pulls endpoints |
 | `localStorage` (browser) | Config persistence |
+| `github-oauth` | `accessToken` signal used as auth fallback when PAT not set |
 
 ### Consumed By
 
 | Module | What is used |
 |--------|-------------|
-| `github-connect` | `connect`, `disconnect`, `pullSpecs`, signals |
+| `github-connect` | `connect`, `connectWithOAuth`, `disconnect`, `pullSpecs`, signals |
 | `editor-page` | `connected`, `createSpecPR` for PR creation |
 
 ## Change Log
@@ -126,3 +135,4 @@ Provides GitHub API integration for the Specl application, enabling users to con
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-02-24 | CorvidAgent | Initial spec — GitHub integration for pull/push/PR workflows |
+| 2026-02-24 | CorvidAgent | Add OAuth token fallback via `GitHubOAuthService`, add `connectWithOAuth` method |

--- a/src/app/components/github-connect/github-connect.html
+++ b/src/app/components/github-connect/github-connect.html
@@ -1,8 +1,19 @@
 <div class="github-section">
   @if (github.connected()) {
+    <!-- Connected to a repo -->
     <div class="github-connected">
       <div class="connection-info">
-        <span class="status-dot connected"></span>
+        @if (oauth.authenticated()) {
+          <img
+            class="avatar"
+            [src]="oauth.avatarUrl()"
+            [alt]="oauth.username()"
+            width="20"
+            height="20"
+          />
+        } @else {
+          <span class="status-dot connected"></span>
+        }
         <span class="connection-label">{{ github.config()?.owner }}/{{ github.config()?.repo }}</span>
       </div>
       <div class="connected-actions">
@@ -10,80 +21,198 @@
           @if (github.loading()) { Pulling... } @else { Pull Specs }
         </button>
         <button class="btn btn-sm" (click)="onDisconnect()">Disconnect</button>
+        @if (oauth.authenticated()) {
+          <button class="btn btn-sm" (click)="onSignOut()">Sign Out</button>
+        }
       </div>
     </div>
-  } @else {
-    <button class="btn btn-sm github-toggle" (click)="toggleForm()">
-      @if (showForm()) { Cancel } @else { Connect GitHub }
-    </button>
-  }
-
-  @if (showForm() && !github.connected()) {
-    <div class="github-form">
-      <label class="form-field">
-        <span class="form-label">Token</span>
-        <input
-          type="password"
-          class="form-input"
-          placeholder="ghp_..."
-          [value]="token()"
-          (input)="updateField('token', $event)"
+  } @else if (oauth.state() === 'awaiting_code' || oauth.state() === 'polling') {
+    <!-- Device flow in progress -->
+    <div class="device-flow">
+      <p class="device-flow-label">Enter this code on GitHub:</p>
+      <div class="device-code-row">
+        <code class="device-code">{{ oauth.userCode() }}</code>
+        <button class="btn btn-sm" (click)="copyCode()">Copy</button>
+      </div>
+      <p class="device-flow-hint">
+        @if (oauth.state() === 'awaiting_code') {
+          Opening GitHub...
+        } @else {
+          Waiting for authorization...
+        }
+      </p>
+      <button class="btn btn-sm" (click)="onCancelFlow()">Cancel</button>
+    </div>
+  } @else if (oauth.authenticated() && !github.connected()) {
+    <!-- Signed in via OAuth but not connected to a repo yet -->
+    <div class="oauth-signed-in">
+      <div class="connection-info">
+        <img
+          class="avatar"
+          [src]="oauth.avatarUrl()"
+          [alt]="oauth.username()"
+          width="20"
+          height="20"
         />
-      </label>
-      <div class="form-row">
-        <label class="form-field">
-          <span class="form-label">Owner</span>
-          <input
-            type="text"
-            class="form-input"
-            placeholder="org or user"
-            [value]="owner()"
-            (input)="updateField('owner', $event)"
-          />
-        </label>
-        <label class="form-field">
-          <span class="form-label">Repo</span>
-          <input
-            type="text"
-            class="form-input"
-            placeholder="repo-name"
-            [value]="repo()"
-            (input)="updateField('repo', $event)"
-          />
-        </label>
+        <span class="connection-label">{{ oauth.username() }}</span>
       </div>
-      <div class="form-row">
-        <label class="form-field">
-          <span class="form-label">Branch</span>
-          <input
-            type="text"
-            class="form-input"
-            placeholder="main"
-            [value]="branch()"
-            (input)="updateField('branch', $event)"
-          />
-        </label>
-        <label class="form-field">
-          <span class="form-label">Specs Path</span>
-          <input
-            type="text"
-            class="form-input"
-            placeholder="specs"
-            [value]="specsPath()"
-            (input)="updateField('specsPath', $event)"
-          />
-        </label>
-      </div>
-      @if (github.error()) {
-        <div class="form-error">{{ github.error() }}</div>
-      }
-      <button
-        class="btn btn-primary btn-sm"
-        (click)="onConnect()"
-        [disabled]="github.loading() || !token() || !owner() || !repo()"
-      >
-        @if (github.loading()) { Connecting... } @else { Connect }
+      <button class="btn btn-sm github-toggle" (click)="toggleForm()">
+        @if (showForm()) { Cancel } @else { Connect Repo }
       </button>
     </div>
+
+    @if (showForm()) {
+      <div class="github-form">
+        <div class="form-row">
+          <label class="form-field">
+            <span class="form-label">Owner</span>
+            <input
+              type="text"
+              class="form-input"
+              placeholder="org or user"
+              [value]="owner()"
+              (input)="updateField('owner', $event)"
+            />
+          </label>
+          <label class="form-field">
+            <span class="form-label">Repo</span>
+            <input
+              type="text"
+              class="form-input"
+              placeholder="repo-name"
+              [value]="repo()"
+              (input)="updateField('repo', $event)"
+            />
+          </label>
+        </div>
+        <div class="form-row">
+          <label class="form-field">
+            <span class="form-label">Branch</span>
+            <input
+              type="text"
+              class="form-input"
+              placeholder="main"
+              [value]="branch()"
+              (input)="updateField('branch', $event)"
+            />
+          </label>
+          <label class="form-field">
+            <span class="form-label">Specs Path</span>
+            <input
+              type="text"
+              class="form-input"
+              placeholder="specs"
+              [value]="specsPath()"
+              (input)="updateField('specsPath', $event)"
+            />
+          </label>
+        </div>
+        @if (github.error()) {
+          <div class="form-error">{{ github.error() }}</div>
+        }
+        <button
+          class="btn btn-primary btn-sm"
+          (click)="onConnect()"
+          [disabled]="github.loading() || !owner() || !repo()"
+        >
+          @if (github.loading()) { Connecting... } @else { Connect }
+        </button>
+        <button class="btn btn-sm" (click)="onSignOut()">Sign Out</button>
+      </div>
+    }
+  } @else {
+    <!-- Not signed in, not connected -->
+    @if (oauthAvailable) {
+      <button class="btn btn-sm btn-github" (click)="onSignIn()">
+        <svg class="github-icon" viewBox="0 0 16 16" width="16" height="16" fill="currentColor">
+          <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38
+            0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52
+            -.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87
+            2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2
+            -.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04
+            2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65
+            3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016
+            8c0-4.42-3.58-8-8-8z"/>
+        </svg>
+        Sign in with GitHub
+      </button>
+    }
+
+    @if (oauth.state() === 'error') {
+      <div class="form-error">{{ oauth.error() }}</div>
+    }
+
+    <button class="btn btn-sm github-toggle" (click)="togglePat()">
+      @if (showForm()) { Cancel } @else { Use Personal Access Token }
+    </button>
+
+    @if (showForm()) {
+      <div class="github-form">
+        <label class="form-field">
+          <span class="form-label">Token</span>
+          <input
+            type="password"
+            class="form-input"
+            placeholder="ghp_..."
+            [value]="token()"
+            (input)="updateField('token', $event)"
+          />
+        </label>
+        <div class="form-row">
+          <label class="form-field">
+            <span class="form-label">Owner</span>
+            <input
+              type="text"
+              class="form-input"
+              placeholder="org or user"
+              [value]="owner()"
+              (input)="updateField('owner', $event)"
+            />
+          </label>
+          <label class="form-field">
+            <span class="form-label">Repo</span>
+            <input
+              type="text"
+              class="form-input"
+              placeholder="repo-name"
+              [value]="repo()"
+              (input)="updateField('repo', $event)"
+            />
+          </label>
+        </div>
+        <div class="form-row">
+          <label class="form-field">
+            <span class="form-label">Branch</span>
+            <input
+              type="text"
+              class="form-input"
+              placeholder="main"
+              [value]="branch()"
+              (input)="updateField('branch', $event)"
+            />
+          </label>
+          <label class="form-field">
+            <span class="form-label">Specs Path</span>
+            <input
+              type="text"
+              class="form-input"
+              placeholder="specs"
+              [value]="specsPath()"
+              (input)="updateField('specsPath', $event)"
+            />
+          </label>
+        </div>
+        @if (github.error()) {
+          <div class="form-error">{{ github.error() }}</div>
+        }
+        <button
+          class="btn btn-primary btn-sm"
+          (click)="onConnect()"
+          [disabled]="github.loading() || !token() || !owner() || !repo()"
+        >
+          @if (github.loading()) { Connecting... } @else { Connect }
+        </button>
+      </div>
+    }
   }
 </div>

--- a/src/app/components/github-connect/github-connect.scss
+++ b/src/app/components/github-connect/github-connect.scss
@@ -1,6 +1,9 @@
 .github-section {
   padding: 12px 16px;
   border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .github-toggle {
@@ -18,6 +21,13 @@
   align-items: center;
   gap: 8px;
   font-size: 13px;
+}
+
+.avatar {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  flex-shrink: 0;
 }
 
 .status-dot {
@@ -42,8 +52,71 @@
 .connected-actions {
   display: flex;
   gap: 6px;
+  flex-wrap: wrap;
 }
 
+// GitHub sign-in button
+.btn-github {
+  width: 100%;
+  background: #24292e;
+  border-color: #24292e;
+  color: #fff;
+  gap: 8px;
+
+  &:hover {
+    background: #2f363d;
+    border-color: #2f363d;
+  }
+}
+
+.github-icon {
+  flex-shrink: 0;
+}
+
+// Device flow UI
+.device-flow {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.device-flow-label {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.device-code-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.device-code {
+  font-size: 20px;
+  font-weight: 700;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  letter-spacing: 0.15em;
+  padding: 8px 14px;
+  background: var(--surface-alt, var(--hover));
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  user-select: all;
+}
+
+.device-flow-hint {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+// OAuth signed in but no repo connected
+.oauth-signed-in {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+// Form
 .github-form {
   display: flex;
   flex-direction: column;

--- a/src/app/components/github-connect/github-connect.ts
+++ b/src/app/components/github-connect/github-connect.ts
@@ -1,5 +1,9 @@
 import { Component, inject, signal, output } from '@angular/core';
 import { GitHubService, type GitHubConfig } from '../../services/github.service';
+import { GitHubOAuthService } from '../../services/github-oauth.service';
+import { environment } from '../../../environments/environment';
+
+type ConnectMode = 'oauth' | 'pat';
 
 @Component({
   selector: 'app-github-connect',
@@ -9,13 +13,17 @@ import { GitHubService, type GitHubConfig } from '../../services/github.service'
 })
 export class GitHubConnectComponent {
   readonly github = inject(GitHubService);
+  readonly oauth = inject(GitHubOAuthService);
 
   readonly showForm = signal(false);
+  readonly connectMode = signal<ConnectMode>('oauth');
   readonly token = signal('');
   readonly owner = signal('');
   readonly repo = signal('');
   readonly branch = signal('main');
   readonly specsPath = signal('specs');
+
+  readonly oauthAvailable = Boolean(environment.GITHUB_CLIENT_ID);
 
   /** Emitted when specs are pulled from GitHub */
   readonly specsPulled = output<{ name: string; content: string; path: string; sha: string }[]>();
@@ -24,15 +32,49 @@ export class GitHubConnectComponent {
     this.showForm.update((v) => !v);
   }
 
+  togglePat(): void {
+    this.showForm.update((v) => !v);
+    this.connectMode.set('pat');
+  }
+
+  setMode(mode: ConnectMode): void {
+    this.connectMode.set(mode);
+  }
+
+  async onSignIn(): Promise<void> {
+    await this.oauth.startDeviceFlow();
+  }
+
+  onCancelFlow(): void {
+    this.oauth.cancelFlow();
+  }
+
+  onSignOut(): void {
+    this.github.disconnect();
+    this.oauth.signOut();
+    this.showForm.set(false);
+  }
+
   async onConnect(): Promise<void> {
-    const config: GitHubConfig = {
-      token: this.token(),
-      owner: this.owner(),
-      repo: this.repo(),
-      branch: this.branch(),
-      specsPath: this.specsPath(),
-    };
-    await this.github.connect(config);
+    if (this.oauth.authenticated()) {
+      // OAuth mode: connect with repo config, token comes from OAuth service
+      await this.github.connectWithOAuth({
+        owner: this.owner(),
+        repo: this.repo(),
+        branch: this.branch(),
+        specsPath: this.specsPath(),
+      });
+    } else {
+      // PAT mode: use the manually entered token
+      const config: GitHubConfig = {
+        token: this.token(),
+        owner: this.owner(),
+        repo: this.repo(),
+        branch: this.branch(),
+        specsPath: this.specsPath(),
+      };
+      await this.github.connect(config);
+    }
   }
 
   onDisconnect(): void {
@@ -43,6 +85,13 @@ export class GitHubConnectComponent {
   async onPull(): Promise<void> {
     const specs = await this.github.pullSpecs();
     this.specsPulled.emit(specs);
+  }
+
+  async copyCode(): Promise<void> {
+    const code = this.oauth.userCode();
+    if (code) {
+      await navigator.clipboard.writeText(code);
+    }
   }
 
   updateField(field: 'token' | 'owner' | 'repo' | 'branch' | 'specsPath', event: Event): void {

--- a/src/app/services/github-oauth.service.ts
+++ b/src/app/services/github-oauth.service.ts
@@ -1,0 +1,264 @@
+import { Injectable, signal, computed } from '@angular/core';
+import { environment } from '../../environments/environment';
+
+export type OAuthState = 'idle' | 'awaiting_code' | 'polling' | 'authenticated' | 'error';
+
+export interface DeviceCodeResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  expires_in: number;
+  interval: number;
+}
+
+const TOKEN_KEY = 'specl:github-oauth-token';
+const USER_KEY = 'specl:github-oauth-user';
+const CORS_PROXY = 'https://corsproxy.io/?url=';
+
+@Injectable({ providedIn: 'root' })
+export class GitHubOAuthService {
+  private readonly _state = signal<OAuthState>(this.restoreState());
+  private readonly _userCode = signal<string | null>(null);
+  private readonly _verificationUri = signal<string | null>(null);
+  private readonly _accessToken = signal<string | null>(this.restoreToken());
+  private readonly _username = signal<string | null>(this.restoreUser()?.login ?? null);
+  private readonly _avatarUrl = signal<string | null>(this.restoreUser()?.avatar_url ?? null);
+  private readonly _error = signal<string | null>(null);
+
+  private pollTimer: ReturnType<typeof setTimeout> | null = null;
+  private cancelled = false;
+
+  readonly state = this._state.asReadonly();
+  readonly userCode = this._userCode.asReadonly();
+  readonly verificationUri = this._verificationUri.asReadonly();
+  readonly accessToken = this._accessToken.asReadonly();
+  readonly username = this._username.asReadonly();
+  readonly avatarUrl = this._avatarUrl.asReadonly();
+  readonly error = this._error.asReadonly();
+
+  readonly authenticated = computed(() => this._accessToken() !== null);
+
+  /**
+   * Start the GitHub OAuth Device Flow.
+   * Requests a device code, then polls for the access token.
+   */
+  async startDeviceFlow(): Promise<void> {
+    const clientId = environment.GITHUB_CLIENT_ID;
+    if (!clientId) {
+      throw new Error('GitHub OAuth Client ID not configured');
+    }
+
+    this.cancelled = false;
+    this._error.set(null);
+    this._state.set('awaiting_code');
+
+    try {
+      // Step 1: Request device and user codes
+      const codeRes = await fetch(`${CORS_PROXY}https://github.com/login/device/code`, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          client_id: clientId,
+          scope: 'repo',
+        }),
+      });
+
+      if (!codeRes.ok) {
+        throw new Error(`Device code request failed: HTTP ${codeRes.status}`);
+      }
+
+      const codeData: DeviceCodeResponse = await codeRes.json();
+      this._userCode.set(codeData.user_code);
+      this._verificationUri.set(codeData.verification_uri);
+
+      // Open GitHub verification page in a new tab
+      window.open(codeData.verification_uri, '_blank', 'noopener');
+
+      // Step 2: Poll for the access token
+      this._state.set('polling');
+      await this.pollForToken(clientId, codeData);
+    } catch (err: unknown) {
+      if (!this.cancelled) {
+        const msg = err instanceof Error ? err.message : 'OAuth flow failed';
+        this._error.set(msg);
+        this._state.set('error');
+      }
+    }
+  }
+
+  /**
+   * Cancel an in-progress device flow.
+   */
+  cancelFlow(): void {
+    this.cancelled = true;
+    if (this.pollTimer) {
+      clearTimeout(this.pollTimer);
+      this.pollTimer = null;
+    }
+    this._state.set('idle');
+    this._userCode.set(null);
+    this._verificationUri.set(null);
+    this._error.set(null);
+  }
+
+  /**
+   * Sign out: clear token, user info, and localStorage.
+   */
+  signOut(): void {
+    this.cancelFlow();
+    this._accessToken.set(null);
+    this._username.set(null);
+    this._avatarUrl.set(null);
+    localStorage.removeItem(TOKEN_KEY);
+    localStorage.removeItem(USER_KEY);
+  }
+
+  // ─── Private helpers ─────────────────────────────────────────────
+
+  private async pollForToken(clientId: string, codeData: DeviceCodeResponse): Promise<void> {
+    let interval = codeData.interval * 1000; // Convert to ms
+    const expiresAt = Date.now() + codeData.expires_in * 1000;
+    let consecutiveFailures = 0;
+
+    while (!this.cancelled) {
+      // Wait for the polling interval
+      await new Promise<void>((resolve) => {
+        this.pollTimer = setTimeout(resolve, interval);
+      });
+
+      if (this.cancelled) return;
+
+      // Check if the code has expired
+      if (Date.now() >= expiresAt) {
+        this._error.set('Device code expired — please try again');
+        this._state.set('error');
+        return;
+      }
+
+      try {
+        const tokenRes = await fetch(`${CORS_PROXY}https://github.com/login/oauth/access_token`, {
+          method: 'POST',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            client_id: clientId,
+            device_code: codeData.device_code,
+            grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+          }),
+        });
+
+        if (!tokenRes.ok) {
+          consecutiveFailures++;
+          if (consecutiveFailures >= 3) {
+            this._error.set('Token polling failed after multiple attempts');
+            this._state.set('error');
+            return;
+          }
+          continue;
+        }
+
+        const tokenData = await tokenRes.json();
+        consecutiveFailures = 0;
+
+        if (tokenData.access_token) {
+          // Success!
+          this._accessToken.set(tokenData.access_token);
+          localStorage.setItem(TOKEN_KEY, tokenData.access_token);
+
+          this._userCode.set(null);
+          this._verificationUri.set(null);
+          this._state.set('authenticated');
+
+          // Fetch user profile
+          await this.fetchUserProfile(tokenData.access_token);
+          return;
+        }
+
+        // Handle pending/error states from GitHub
+        switch (tokenData.error) {
+          case 'authorization_pending':
+            // User hasn't authorized yet — keep polling
+            break;
+
+          case 'slow_down':
+            // Increase interval by 5 seconds
+            interval += 5000;
+            break;
+
+          case 'expired_token':
+            this._error.set('Device code expired — please try again');
+            this._state.set('error');
+            return;
+
+          case 'access_denied':
+            this._error.set('Authorization was denied');
+            this._state.set('error');
+            return;
+
+          default:
+            this._error.set(tokenData.error_description ?? tokenData.error ?? 'Unknown OAuth error');
+            this._state.set('error');
+            return;
+        }
+      } catch {
+        consecutiveFailures++;
+        if (consecutiveFailures >= 3) {
+          this._error.set('Token polling failed after multiple attempts');
+          this._state.set('error');
+          return;
+        }
+      }
+    }
+  }
+
+  private async fetchUserProfile(token: string): Promise<void> {
+    try {
+      const res = await fetch('https://api.github.com/user', {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/vnd.github+json',
+        },
+      });
+
+      if (res.ok) {
+        const user = await res.json();
+        this._username.set(user.login);
+        this._avatarUrl.set(user.avatar_url);
+        localStorage.setItem(USER_KEY, JSON.stringify({ login: user.login, avatar_url: user.avatar_url }));
+      }
+    } catch {
+      // Non-fatal: token works but we couldn't get user info
+    }
+  }
+
+  private restoreToken(): string | null {
+    try {
+      return localStorage.getItem(TOKEN_KEY);
+    } catch {
+      return null;
+    }
+  }
+
+  private restoreUser(): { login: string; avatar_url: string } | null {
+    try {
+      const raw = localStorage.getItem(USER_KEY);
+      if (!raw) return null;
+      return JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+
+  private restoreState(): OAuthState {
+    try {
+      return localStorage.getItem(TOKEN_KEY) ? 'authenticated' : 'idle';
+    } catch {
+      return 'idle';
+    }
+  }
+}

--- a/src/app/services/github.service.ts
+++ b/src/app/services/github.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, signal, computed } from '@angular/core';
+import { Injectable, inject, signal, computed } from '@angular/core';
+import { GitHubOAuthService } from './github-oauth.service';
 
 export interface GitHubConfig {
   token: string;
@@ -26,6 +27,7 @@ const STORAGE_KEY = 'specl:github-config';
 
 @Injectable({ providedIn: 'root' })
 export class GitHubService {
+  private readonly oauth = inject(GitHubOAuthService);
   private readonly _config = signal<GitHubConfig | null>(this.loadConfig());
   private readonly _connected = signal(false);
   private readonly _loading = signal(false);
@@ -65,6 +67,21 @@ export class GitHubService {
     } finally {
       this._loading.set(false);
     }
+  }
+
+  /**
+   * Connect using only the OAuth token (no PAT needed).
+   * Requires owner, repo, branch, and specsPath — token comes from GitHubOAuthService.
+   */
+  async connectWithOAuth(repoConfig: Omit<GitHubConfig, 'token'>): Promise<boolean> {
+    const oauthToken = this.oauth.accessToken();
+    if (!oauthToken) {
+      this._error.set('Not signed in with GitHub OAuth');
+      return false;
+    }
+
+    const config: GitHubConfig = { ...repoConfig, token: '' };
+    return this.connect(config);
   }
 
   /**
@@ -293,8 +310,10 @@ export class GitHubService {
       'X-GitHub-Api-Version': '2022-11-28',
     };
 
-    if (cfg?.token) {
-      headers['Authorization'] = `Bearer ${cfg.token}`;
+    // Use PAT if available, otherwise fall back to OAuth token
+    const token = cfg?.token || this.oauth.accessToken();
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
     }
 
     return fetch(`https://api.github.com${path}`, {

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,0 +1,10 @@
+export const environment = {
+  /**
+   * GitHub OAuth App Client ID for the device flow.
+   * Create one at https://github.com/settings/applications/new
+   * - Application name: Specl
+   * - Homepage URL: https://specl.app (or your deployment URL)
+   * - Enable "Device Authorization Flow" in the app settings
+   */
+  GITHUB_CLIENT_ID: '',
+};


### PR DESCRIPTION
## Summary
- Add full GitHub integration: pull specs from a repo, push changes to branches, and create PRs — all via the GitHub REST API
- Add GitHub OAuth Device Flow (RFC 8628) as the primary auth method with a "Sign in with GitHub" button, keeping PAT as a fallback
- Add mobile-responsive layout, CI spec validation workflow, and spec-check CLI tooling

## Changes

### GitHub Integration (`99e24bc`)
- **GitHubService** — REST API client with PAT auth for pulling `.spec.md` files, pushing changes to new branches, and creating PRs
- **GitHubConnectComponent** — sidebar panel for repo connection (owner/repo/branch/path config, pull/disconnect controls)
- **Editor page** — "Create PR" button for GitHub-sourced specs
- **Spec model** — `githubSha` field for tracking remote blob state
- Specs for `github-service` and `github-connect`, updates to 5 existing specs

### OAuth Device Flow (`f94c0b1`)
- **GitHubOAuthService** — full device flow lifecycle: device code request, token polling with `slow_down`/`expired_token` handling, user profile fetch, localStorage persistence
- **Environment config** — `GITHUB_CLIENT_ID` for the OAuth App
- **GitHubConnectComponent** overhaul — four UI states: sign-in, device code display, authenticated + repo config, connected
- **GitHubService** — falls back to OAuth token when no PAT configured, `connectWithOAuth()` method

### Mobile & Tooling (`293aa04`)
- Mobile-responsive layout with sidebar overlay and section nav toggle
- `spec-check` CI workflow (`.github/workflows/ci.yml`) validates `.spec.md` on push/PR
- `spec-check` CLI tool and npm script
- `CLAUDE.md` agent instructions and `.speckit/` constitution
- Fix validator false-positive for sections with subsections

## Test plan
- [ ] Verify `npm run spec-check` passes all 15 specs
- [ ] Verify `ng build` succeeds with no errors
- [ ] Test GitHub PAT flow: enter token, connect to repo, pull specs, disconnect
- [ ] Test OAuth Device Flow: click "Sign in with GitHub", verify user code appears, complete authorization, confirm avatar/username shown
- [ ] Test "Create PR" from editor page with a GitHub-sourced spec
- [ ] Test mobile layout: sidebar overlay, section nav toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)