### PR TITLE
fix: add GitHub App client ID for device flow OAuth

### DIFF
--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -6,5 +6,5 @@ export const environment = {
    * - Homepage URL: https://specl.app (or your deployment URL)
    * - Enable "Device Authorization Flow" in the app settings
    */
-  GITHUB_CLIENT_ID: '',
+  GITHUB_CLIENT_ID: 'Iv23liZ0jZ5S5XazEgWI',
 };


### PR DESCRIPTION
## Summary
- Adds the GitHub App client ID (`Iv23liZ0jZ5S5XazEgWI`) to `src/environments/environment.ts`
- This enables OAuth device flow authentication in the Specl app

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)