### PR TITLE
fix: show clickable verification link in OAuth device flow

### DIFF
--- a/src/app/components/github-connect/github-connect.html
+++ b/src/app/components/github-connect/github-connect.html
@@ -35,10 +35,13 @@
         <button class="btn btn-sm" (click)="copyCode()">Copy</button>
       </div>
       <p class="device-flow-hint">
-        @if (oauth.state() === 'awaiting_code') {
-          Opening GitHub...
-        } @else {
-          Waiting for authorization...
+        @if (oauth.verificationUri()) {
+          <a [href]="oauth.verificationUri()" target="_blank" rel="noopener" class="verification-link">
+            Open GitHub to enter your code
+          </a>
+        }
+        @if (oauth.state() === 'polling') {
+          <span class="polling-status">Waiting for authorization...</span>
         }
       </p>
       <button class="btn btn-sm" (click)="onCancelFlow()">Cancel</button>

--- a/src/app/components/github-connect/github-connect.scss
+++ b/src/app/components/github-connect/github-connect.scss
@@ -106,6 +106,23 @@
 .device-flow-hint {
   font-size: 12px;
   color: var(--text-muted);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.verification-link {
+  color: var(--accent, #58a6ff);
+  text-decoration: underline;
+  font-weight: 500;
+
+  &:hover {
+    color: var(--accent-hover, #79b8ff);
+  }
+}
+
+.polling-status {
+  font-style: italic;
 }
 
 // OAuth signed in but no repo connected


### PR DESCRIPTION
## Summary
- Adds a clickable "Open GitHub to enter your code" link in the OAuth device flow UI
- Fixes popup blocker issue where `window.open()` after an async `fetch()` gets silently blocked since it's no longer a direct user gesture
- Adds styling for the verification link and polling status

## Test plan
- [ ] Start the OAuth device flow by clicking "Sign in with GitHub"
- [ ] Verify the clickable link appears and opens GitHub in a new tab
- [ ] Verify the device code can be entered and authorization completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)