### PR TITLE
fix: spec list scrolling and default category sort order

### DIFF
--- a/src/app/components/spec-list/spec-list.html
+++ b/src/app/components/spec-list/spec-list.html
@@ -5,7 +5,7 @@
   </div>
 
   <div class="suite-scroll-area">
-    @for (entry of store.suites() | keyvalue; track entry.key) {
+    @for (entry of store.suites() | keyvalue:suiteOrder; track entry.key) {
       <div class="suite-group">
         <button
           class="suite-header"

--- a/src/app/components/spec-list/spec-list.scss
+++ b/src/app/components/spec-list/spec-list.scss
@@ -1,7 +1,15 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
 .spec-list {
   display: flex;
   flex-direction: column;
   flex: 1;
+  min-height: 0;
   overflow: hidden;
   padding: 12px;
 }

--- a/src/app/components/spec-list/spec-list.ts
+++ b/src/app/components/spec-list/spec-list.ts
@@ -80,6 +80,13 @@ export class SpecListComponent {
     return this.collapsedSuites().has(suiteName);
   }
 
+  /** Comparator for keyvalue pipe: 'default' first, then alphabetical */
+  suiteOrder = (a: { key: string }, b: { key: string }): number => {
+    if (a.key === 'default') return -1;
+    if (b.key === 'default') return 1;
+    return a.key.localeCompare(b.key);
+  };
+
   /** Extract a one-line preview from the spec body */
   getPreview(spec: Spec): string {
     if (!spec.body) return 'No description';


### PR DESCRIPTION
## Summary
- **Spec list now scrolls**: Added `:host` flex styles so the Angular component element participates in the sidebar's flex layout. Without this, `overflow-y: auto` on `.suite-scroll-area` had no bounded height and couldn't scroll.
- **Default category pinned to top**: Added a `suiteOrder` comparator to the `keyvalue` pipe so the `default` suite always appears first, with remaining suites sorted alphabetically.

## Test plan
- [ ] Open a repo with enough specs to overflow the sidebar — verify the list scrolls
- [ ] Verify the "default" category appears at the top of the spec list
- [ ] Verify other categories remain in alphabetical order below "default"

🤖 Generated with [Claude Code](https://claude.com/claude-code)