### PR TITLE
fix: enable multiline markdown editing in CodeMirror editors

### DIFF
--- a/src/app/components/markdown-editor/markdown-editor.scss
+++ b/src/app/components/markdown-editor/markdown-editor.scss
@@ -7,4 +7,8 @@
 .editor-host {
   flex: 1;
   overflow: hidden;
+
+  :host ::ng-deep .cm-editor {
+    height: 100%;
+  }
 }

--- a/src/app/components/markdown-editor/markdown-editor.ts
+++ b/src/app/components/markdown-editor/markdown-editor.ts
@@ -53,6 +53,7 @@ export class MarkdownEditorComponent implements OnDestroy {
           extensions: [
             lineNumbers(),
             highlightActiveLine(),
+            EditorView.lineWrapping,
             history(),
             keymap.of([...defaultKeymap, ...historyKeymap]),
             markdown(),

--- a/src/app/components/section-editor/section-editor.ts
+++ b/src/app/components/section-editor/section-editor.ts
@@ -74,6 +74,7 @@ export class SectionEditorComponent implements OnDestroy {
           extensions: [
             lineNumbers(),
             highlightActiveLine(),
+            EditorView.lineWrapping,
             history(),
             keymap.of([...defaultKeymap, ...historyKeymap]),
             markdown(),


### PR DESCRIPTION
## Summary
- Adds `EditorView.lineWrapping` to both `SectionEditorComponent` and `MarkdownEditorComponent` CodeMirror configurations
- Adds `::ng-deep .cm-editor { height: 100% }` to `markdown-editor.scss` so the editor fills its container
- Without `lineWrapping`, CodeMirror renders all content on a single visual line with horizontal scrolling instead of wrapping text across multiple lines

## Root Cause
CodeMirror 6 does **not** enable line wrapping by default. The `EditorView.lineWrapping` extension must be explicitly added to the extensions array. Both editor components were missing this extension, causing text to appear confined to a single line.

## Test plan
- [ ] Open a spec with long markdown content in the section editor
- [ ] Verify text wraps to fill the editor area instead of scrolling horizontally
- [ ] Verify the editor fills the full available height
- [ ] Build passes: `bun run build` completes with no errors

Fixes #11