### PR TITLE
feat: support linking specs as dependencies

### DIFF
--- a/src/app/components/frontmatter-editor/frontmatter-editor.html
+++ b/src/app/components/frontmatter-editor/frontmatter-editor.html
@@ -92,9 +92,15 @@
       <input
         type="text"
         [(ngModel)]="newDep"
-        placeholder="specs/category/dep.spec.md"
+        placeholder="module-name"
+        list="dep-suggestions"
         (keyup.enter)="addDependency()"
       />
+      <datalist id="dep-suggestions">
+        @for (mod of availableModules(); track mod) {
+          <option [value]="mod"></option>
+        }
+      </datalist>
       <button class="btn btn-sm" (click)="addDependency()">Add</button>
     </div>
   </div>

--- a/src/app/components/frontmatter-editor/frontmatter-editor.ts
+++ b/src/app/components/frontmatter-editor/frontmatter-editor.ts
@@ -1,4 +1,4 @@
-import { Component, input, output } from '@angular/core';
+import { Component, computed, input, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { type SpecFrontmatter, type SpecStatus } from '../../models/spec.model';
 
@@ -12,6 +12,15 @@ import { type SpecFrontmatter, type SpecStatus } from '../../models/spec.model';
 export class FrontmatterEditorComponent {
   readonly frontmatter = input.required<SpecFrontmatter>();
   readonly frontmatterChange = output<SpecFrontmatter>();
+  /** All known module names across specs, for dependency autocomplete */
+  readonly knownModules = input<string[]>([]);
+
+  /** Modules available as suggestions — excludes the current module and already-added deps */
+  protected readonly availableModules = computed(() => {
+    const current = this.frontmatter().module;
+    const existing = new Set(this.frontmatter().depends_on);
+    return this.knownModules().filter((m) => m !== current && !existing.has(m));
+  });
 
   protected newFile = '';
   protected newTable = '';

--- a/src/app/pages/editor/editor-page.html
+++ b/src/app/pages/editor/editor-page.html
@@ -66,6 +66,7 @@
               <div class="section-panel-body">
                 <app-frontmatter-editor
                   [frontmatter]="frontmatter()"
+                  [knownModules]="knownModules()"
                   (frontmatterChange)="onFrontmatterChange($event)"
                 />
               </div>

--- a/src/app/pages/editor/editor-page.ts
+++ b/src/app/pages/editor/editor-page.ts
@@ -58,6 +58,14 @@ export class EditorPageComponent implements OnInit {
 
   protected readonly sections = computed(() => this.spec()?.sections ?? []);
 
+  /** All known module names across specs, for dependency autocomplete */
+  protected readonly knownModules = computed(() => {
+    return this.store.allSpecs()
+      .map((s) => s.frontmatter.module)
+      .filter(Boolean)
+      .sort();
+  });
+
   // Sections excluding the level-1 title (for nav and editing)
   protected readonly editableSections = computed(() => {
     return this.sections().filter((s) => s.level >= 2);

--- a/src/app/services/spec-store.service.ts
+++ b/src/app/services/spec-store.service.ts
@@ -106,7 +106,10 @@ export class SpecStoreService {
   validateActiveSpec(): ValidationResult | null {
     const spec = this.activeSpec();
     if (!spec) return null;
-    return this.validator.validate(spec);
+    const knownModules = this.specs()
+      .map((s) => s.frontmatter.module)
+      .filter(Boolean);
+    return this.validator.validate(spec, knownModules);
   }
 
   private inferSuite(pathOrName: string): string {

--- a/src/app/services/spec-validator.service.ts
+++ b/src/app/services/spec-validator.service.ts
@@ -8,11 +8,18 @@ import {
 
 @Injectable({ providedIn: 'root' })
 export class SpecValidatorService {
-  validate(spec: Spec): ValidationResult {
+  /**
+   * Validate a spec. When knownModules is provided, also checks that
+   * depends_on entries reference existing specs.
+   */
+  validate(spec: Spec, knownModules?: string[]): ValidationResult {
     const errors: ValidationError[] = [];
 
     this.validateFrontmatter(spec, errors);
     this.validateSections(spec, errors);
+    if (knownModules) {
+      this.validateDependencyRefs(spec, knownModules, errors);
+    }
 
     return {
       valid: errors.every((e) => e.level === 'warning'),
@@ -42,6 +49,23 @@ export class SpecValidatorService {
     for (const file of fm.files) {
       if (!file || file.trim() === '') {
         errors.push({ level: 'error', field: 'files', message: 'File paths must not be empty' });
+      }
+    }
+  }
+
+  private validateDependencyRefs(
+    spec: Spec,
+    knownModules: string[],
+    errors: ValidationError[],
+  ): void {
+    const known = new Set(knownModules);
+    for (const dep of spec.frontmatter.depends_on) {
+      if (!known.has(dep)) {
+        errors.push({
+          level: 'warning',
+          field: 'depends_on',
+          message: `Dependency "${dep}" does not match any known spec module`,
+        });
       }
     }
   }

--- a/tools/spec-check.ts
+++ b/tools/spec-check.ts
@@ -6,6 +6,7 @@
  *   bun tools/spec-check.ts [paths...]
  *   bun tools/spec-check.ts specs/
  *   bun tools/spec-check.ts specs/models/spec-models.spec.md
+ *   bun tools/spec-check.ts --deps specs/       # show dependency graph
  *
  * Exit codes:
  *   0 — all specs valid
@@ -218,9 +219,136 @@ function walkDir(dir: string, files: string[]): void {
   }
 }
 
+// ─── Cross-spec dependency validation ────────────────────────────────
+interface ParsedSpec {
+  file: string;
+  frontmatter: SpecFrontmatter;
+  sections: SpecSection[];
+}
+
+function validateDependencyRefs(
+  specs: ParsedSpec[],
+): Map<string, ValidationError[]> {
+  const knownModules = new Set(specs.map((s) => s.frontmatter.module).filter(Boolean));
+  const errorsByFile = new Map<string, ValidationError[]>();
+
+  for (const spec of specs) {
+    const errors: ValidationError[] = [];
+    for (const dep of spec.frontmatter.depends_on) {
+      if (!knownModules.has(dep)) {
+        errors.push({
+          level: 'warning',
+          field: 'depends_on',
+          message: `Dependency "${dep}" does not match any known spec module`,
+        });
+      }
+    }
+    if (errors.length > 0) {
+      errorsByFile.set(spec.file, errors);
+    }
+  }
+
+  return errorsByFile;
+}
+
+function detectCycles(specs: ParsedSpec[]): string[][] {
+  const graph = new Map<string, string[]>();
+  for (const spec of specs) {
+    if (spec.frontmatter.module) {
+      graph.set(spec.frontmatter.module, spec.frontmatter.depends_on);
+    }
+  }
+
+  const cycles: string[][] = [];
+  const visited = new Set<string>();
+  const inStack = new Set<string>();
+
+  function dfs(node: string, path: string[]): void {
+    if (inStack.has(node)) {
+      const cycleStart = path.indexOf(node);
+      cycles.push([...path.slice(cycleStart), node]);
+      return;
+    }
+    if (visited.has(node)) return;
+
+    visited.add(node);
+    inStack.add(node);
+    path.push(node);
+
+    for (const dep of graph.get(node) ?? []) {
+      if (graph.has(dep)) {
+        dfs(dep, path);
+      }
+    }
+
+    path.pop();
+    inStack.delete(node);
+  }
+
+  for (const mod of graph.keys()) {
+    dfs(mod, []);
+  }
+
+  return cycles;
+}
+
+function printDependencyGraph(specs: ParsedSpec[]): void {
+  const specsByModule = new Map<string, ParsedSpec>();
+  for (const spec of specs) {
+    if (spec.frontmatter.module) {
+      specsByModule.set(spec.frontmatter.module, spec);
+    }
+  }
+
+  // Build reverse dependency map (consumed by)
+  const consumedBy = new Map<string, string[]>();
+  for (const spec of specs) {
+    for (const dep of spec.frontmatter.depends_on) {
+      const existing = consumedBy.get(dep) ?? [];
+      existing.push(spec.frontmatter.module);
+      consumedBy.set(dep, existing);
+    }
+  }
+
+  console.log('Dependency Graph\n');
+
+  // Sort by module name for consistent output
+  const sorted = [...specsByModule.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+
+  for (const [mod, spec] of sorted) {
+    const deps = spec.frontmatter.depends_on;
+    const dependents = consumedBy.get(mod) ?? [];
+    const relPath = relative(process.cwd(), spec.file);
+
+    console.log(`  ${mod}  (${relPath})`);
+    if (deps.length > 0) {
+      console.log(`    depends on: ${deps.join(', ')}`);
+    }
+    if (dependents.length > 0) {
+      console.log(`    used by:    ${dependents.join(', ')}`);
+    }
+    if (deps.length === 0 && dependents.length === 0) {
+      console.log('    (no dependencies)');
+    }
+    console.log('');
+  }
+
+  // Show cycles if any
+  const cycles = detectCycles(specs);
+  if (cycles.length > 0) {
+    console.log('Circular dependencies detected:\n');
+    for (const cycle of cycles) {
+      console.log(`  ${cycle.join(' -> ')}`);
+    }
+    console.log('');
+  }
+}
+
 // ─── Main ───────────────────────────────────────────────────────────
 const args = process.argv.slice(2);
-const paths = args.length > 0 ? args : ['specs/'];
+const showDeps = args.includes('--deps');
+const paths = args.filter((a) => a !== '--deps');
+if (paths.length === 0) paths.push('specs/');
 
 const specFiles = findSpecFiles(paths);
 
@@ -229,22 +357,41 @@ if (specFiles.length === 0) {
   process.exit(2);
 }
 
+// Parse all specs up front for cross-spec validation
+const parsedSpecs: ParsedSpec[] = specFiles.map((file) => {
+  const raw = readFileSync(file, 'utf-8');
+  const { frontmatter, body } = extractFrontmatter(raw);
+  const sections = parseSections(body);
+  return { file, frontmatter, sections };
+});
+
+// ─── --deps mode: print graph and exit ──────────────────────────────
+if (showDeps) {
+  printDependencyGraph(parsedSpecs);
+  process.exit(0);
+}
+
+// ─── Normal validation mode ─────────────────────────────────────────
+const depErrors = validateDependencyRefs(parsedSpecs);
+const cycles = detectCycles(parsedSpecs);
+
 let totalErrors = 0;
 let totalWarnings = 0;
 let failedFiles = 0;
 
 console.log(`Checking ${specFiles.length} spec file(s)...\n`);
 
-for (const file of specFiles) {
-  const raw = readFileSync(file, 'utf-8');
-  const { frontmatter, body } = extractFrontmatter(raw);
-  const sections = parseSections(body);
-  const errors = validate(frontmatter, sections);
+for (const spec of parsedSpecs) {
+  const errors = validate(spec.frontmatter, spec.sections);
+
+  // Merge in cross-spec dependency warnings
+  const crossErrors = depErrors.get(spec.file) ?? [];
+  errors.push(...crossErrors);
 
   const fileErrors = errors.filter((e) => e.level === 'error');
   const fileWarnings = errors.filter((e) => e.level === 'warning');
 
-  const relPath = relative(process.cwd(), file);
+  const relPath = relative(process.cwd(), spec.file);
 
   if (fileErrors.length === 0 && fileWarnings.length === 0) {
     console.log(`  PASS  ${relPath}`);
@@ -266,6 +413,15 @@ for (const file of specFiles) {
 
   totalErrors += fileErrors.length;
   totalWarnings += fileWarnings.length;
+}
+
+// Report cycles
+if (cycles.length > 0) {
+  console.log('\nCircular dependencies detected:');
+  for (const cycle of cycles) {
+    console.log(`  ${cycle.join(' -> ')}`);
+  }
+  totalWarnings += cycles.length;
 }
 
 console.log('');


### PR DESCRIPTION
## Summary

- Adds cross-spec dependency validation to `spec-check` CLI — warns when `depends_on` entries reference module names that don't match any known spec
- Adds circular dependency detection across the full dependency graph
- Adds `--deps` flag to `spec-check` for viewing the complete dependency graph with "depends on" and "used by" relationships
- Adds datalist autocomplete for the dependency input in the frontmatter editor UI, suggesting known module names (excluding self and already-added deps)
- Adds cross-spec validation to the Angular `SpecValidatorService` so the browser editor can also validate dependency references

Fixes #13

## Test plan

- [x] `bun tools/spec-check.ts specs/` — validates all specs and reports cross-spec dependency warnings + cycle detection
- [x] `bun tools/spec-check.ts --deps specs/` — displays full dependency graph
- [ ] Verify frontmatter editor shows autocomplete suggestions when typing a dependency name
- [ ] Verify validation in the browser warns on unknown dependency references