### PR TITLE
feat: add arrow icons to Prev and Next buttons

### DIFF
--- a/specs/components/section-editor.spec.md
+++ b/specs/components/section-editor.spec.md
@@ -114,3 +114,4 @@ Provides a focused editing interface for a single spec section. Renders an edita
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-02-24 | CorvidAgent | Initial spec |
+| 2026-02-24 | CorvidAgent | Add arrow icons to Prev/Next buttons (#17) |

--- a/src/app/components/section-editor/section-editor.html
+++ b/src/app/components/section-editor/section-editor.html
@@ -11,10 +11,10 @@
     </div>
     <div class="section-nav-buttons">
       @if (hasPrev) {
-        <button class="btn btn-sm" (click)="goPrev()">Prev</button>
+        <button class="btn btn-sm" (click)="goPrev()">&#8592; Prev</button>
       }
       @if (hasNext) {
-        <button class="btn btn-sm" (click)="goNext()">Next</button>
+        <button class="btn btn-sm" (click)="goNext()">Next &#8594;</button>
       }
     </div>
   </header>


### PR DESCRIPTION
## Summary
- Added left arrow (←) to the Prev button and right arrow (→) to the Next button in the section editor navigation
- Uses HTML entities (`&#8592;` and `&#8594;`) consistent with the existing icon approach in the codebase
- Updated the section-editor spec change log

Fixes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)