### PR TITLE
fix: use accent color for active Edit/Preview tab

### DIFF
--- a/src/app/pages/editor/editor-page.scss
+++ b/src/app/pages/editor/editor-page.scss
@@ -67,8 +67,8 @@
   transition: all 0.15s;
 
   &.active {
-    background: var(--surface);
-    color: var(--text-primary);
+    background: var(--accent);
+    color: #fff;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
   }
 


### PR DESCRIPTION
## Summary
- Changes the active state of the Edit/Preview toggle button to use the purple accent color (`var(--accent)`) as the background with white text
- Makes the selected tab state significantly more visually distinct and clear

Fixes #19