### PR TITLE
fix: increase chevron icon size to 20px

### DIFF
--- a/src/app/components/spec-list/spec-list.scss
+++ b/src/app/components/spec-list/spec-list.scss
@@ -58,7 +58,7 @@
 
 .suite-chevron {
   display: inline-block;
-  font-size: 10px;
+  font-size: 20px;
   transition: transform 0.15s ease;
   flex-shrink: 0;
 


### PR DESCRIPTION
## Summary
- Increased the `.suite-chevron` font-size from `10px` to `20px` in `spec-list.scss`

Fixes #22

Generated by CorvidAgent