### PR TITLE
fix: move Next button from section panel footer to header

### DIFF
--- a/src/app/pages/editor/editor-page.html
+++ b/src/app/pages/editor/editor-page.html
@@ -66,8 +66,15 @@
           @if (activeSectionIndex() === -1) {
             <div class="section-panel">
               <div class="section-panel-header">
-                <h2>Frontmatter</h2>
-                <p class="section-hint">Module metadata, files, dependencies, and configuration.</p>
+                <div class="section-panel-header-text">
+                  <h2>Frontmatter</h2>
+                  <p class="section-hint">Module metadata, files, dependencies, and configuration.</p>
+                </div>
+                @if (editableSections().length > 0) {
+                  <div class="section-nav-buttons">
+                    <button class="btn btn-sm" (click)="onNavigate(0)">Next &#8594;</button>
+                  </div>
+                }
               </div>
               <div class="section-panel-body">
                 <app-frontmatter-editor
@@ -76,13 +83,6 @@
                   (frontmatterChange)="onFrontmatterChange($event)"
                 />
               </div>
-              <footer class="section-panel-footer">
-                @if (editableSections().length > 0) {
-                  <button class="btn btn-primary btn-sm" (click)="onNavigate(0)">
-                    Next: {{ editableSections()[0].heading }}
-                  </button>
-                }
-              </footer>
             </div>
           } @else if (activeEditableSection(); as sec) {
             <app-section-editor

--- a/src/app/pages/editor/editor-page.scss
+++ b/src/app/pages/editor/editor-page.scss
@@ -123,8 +123,12 @@
 }
 
 .section-panel-header {
-  padding: 16px 20px 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 20px;
   border-bottom: 1px solid var(--border);
+  gap: 12px;
 
   h2 {
     font-size: 18px;
@@ -138,18 +142,17 @@
     color: var(--text-muted);
     margin: 0;
   }
+
+  .section-nav-buttons {
+    display: flex;
+    gap: 6px;
+    flex-shrink: 0;
+  }
 }
 
 .section-panel-body {
   flex: 1;
   overflow-y: auto;
-}
-
-.section-panel-footer {
-  padding: 12px 20px;
-  border-top: 1px solid var(--border);
-  display: flex;
-  justify-content: flex-end;
 }
 
 .pr-banner {
@@ -211,14 +214,10 @@
   }
 
   .section-panel-header {
-    padding: 12px 16px 8px;
+    padding: 12px 16px;
   }
 
   .section-panel-body {
     padding: 0;
-  }
-
-  .section-panel-footer {
-    padding: 8px 16px;
   }
 }


### PR DESCRIPTION
## Summary
- Removes the `<footer class="section-panel-footer">` from the Frontmatter section panel
- Moves the "Next" navigation button into the `.section-panel-header`, matching the pattern used by the `section-editor` component's Prev/Next header buttons
- Cleans up the now-unused `.section-panel-footer` CSS (including mobile styles)

Fixes #27

## Test plan
- [ ] Open a spec in the editor and verify the Frontmatter section panel no longer has a footer
- [ ] Verify the "Next →" button appears in the header, right-aligned
- [ ] Click the "Next →" button and confirm it navigates to the first editable section
- [ ] Verify the layout looks correct on mobile viewports
- [ ] Compare with section-editor header nav buttons to confirm consistent styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)