### PR TITLE
feat: add import icon to Import buttons

### DIFF
--- a/src/app/components/spec-list/spec-list.html
+++ b/src/app/components/spec-list/spec-list.html
@@ -1,7 +1,10 @@
 <div class="spec-list">
   <div class="actions">
     <button class="btn btn-primary" (click)="onCreateSpec()">+ New Spec</button>
-    <button class="btn btn-secondary" (click)="onImport()">Import</button>
+    <button class="btn btn-secondary" (click)="onImport()">
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+      Import
+    </button>
   </div>
 
   <div class="suite-scroll-area">

--- a/src/app/components/welcome/welcome.html
+++ b/src/app/components/welcome/welcome.html
@@ -8,6 +8,7 @@
         Create New Spec
       </button>
       <button class="btn btn-secondary btn-lg" (click)="onImport()">
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
         Import .spec.md Files
       </button>
     </div>


### PR DESCRIPTION
## Summary
- Adds an inline SVG import icon (arrow-into-tray) in front of the "Import" text on both the welcome page and the spec list sidebar
- Uses `currentColor` to inherit the button text color, matching the existing icon pattern (e.g. GitHub logo SVG)
- Welcome page icon is 18px, sidebar icon is 16px to match their respective button sizes

Fixes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)