### PR TITLE
a11y: preserve visible focus indicators for keyboard navigation

### DIFF
--- a/src/app/components/section-editor/section-editor.scss
+++ b/src/app/components/section-editor/section-editor.scss
@@ -94,7 +94,13 @@
   line-height: 1.6;
   resize: vertical;
 
-  &:focus {
+  &:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-color: var(--accent);
+  }
+
+  &:focus:not(:focus-visible) {
     outline: none;
     border-color: var(--accent);
     box-shadow: 0 0 0 2px var(--accent-ring);

--- a/src/app/components/table-editor/table-editor.scss
+++ b/src/app/components/table-editor/table-editor.scss
@@ -65,7 +65,14 @@ tbody {
     border-color: var(--border);
   }
 
-  &:focus {
+  &:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-color: var(--accent);
+    background: var(--surface);
+  }
+
+  &:focus:not(:focus-visible) {
     outline: none;
     border-color: var(--accent);
     background: var(--surface);


### PR DESCRIPTION
## Summary

- Fixes `.cell-input` (table-editor) and `.text-block` (section-editor) which used `:focus { outline: none }`, overriding the global `*:focus-visible` focus ring
- Replaces blanket `:focus` rules with `:focus-visible` (for keyboard) and `:focus:not(:focus-visible)` (for mouse/touch), restoring WCAG 2.1 AA SC 2.4.7 compliance
- All other interactive elements (`.tab`, `.suite-header`, `.nav-item`, `.btn-icon`) already correctly inherit the global focus ring from `styles.scss`

## Test plan

- [ ] Tab through table editor cells — should show 2px accent outline
- [ ] Tab through section editor text blocks — should show 2px accent outline
- [ ] Click into the same elements — should show box-shadow ring (no outline)
- [ ] Verify all 173 existing tests still pass (`ng test --watch=false`)
- [ ] Verify production build succeeds (`ng build`)

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)