### PR TITLE
a11y: make hidden buttons visible on keyboard focus

### DIFF
--- a/src/app/components/spec-list/spec-list.scss
+++ b/src/app/components/spec-list/spec-list.scss
@@ -170,7 +170,8 @@
   transition: opacity 0.15s;
   flex-shrink: 0;
 
-  .spec-item:hover & {
+  .spec-item:hover &,
+  &:focus-visible {
     opacity: 0.6;
   }
 

--- a/src/app/components/table-editor/table-editor.scss
+++ b/src/app/components/table-editor/table-editor.scss
@@ -102,7 +102,8 @@ tbody {
   opacity: 0;
   transition: opacity 0.15s;
 
-  tr:hover & {
+  tr:hover &,
+  tr:focus-within & {
     opacity: 1;
   }
 }


### PR DESCRIPTION
## Summary
- **table-editor**: Show row actions via `tr:focus-within` when any child button receives keyboard focus (fixes #51)
- **spec-list**: Show delete button on `:focus-visible` when it receives keyboard focus (fixes #52)

## Test plan
- [x] All 173 existing unit tests pass
- [ ] Manual: Tab through table editor rows — action buttons should appear when focused
- [ ] Manual: Tab to delete button in spec list — button should become visible

Closes #51
Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)