### PR TITLE
fix(a11y): make hover-revealed controls visible on keyboard focus

### DIFF
--- a/src/app/components/spec-list/spec-list.scss
+++ b/src/app/components/spec-list/spec-list.scss
@@ -170,7 +170,8 @@
   transition: opacity 0.15s;
   flex-shrink: 0;
 
-  .spec-item:hover & {
+  .spec-item:hover &,
+  &:focus-visible {
     opacity: 0.6;
   }
 

--- a/src/app/components/table-editor/table-editor.scss
+++ b/src/app/components/table-editor/table-editor.scss
@@ -102,7 +102,8 @@ tbody {
   opacity: 0;
   transition: opacity 0.15s;
 
-  tr:hover & {
+  tr:hover &,
+  tr:focus-within & {
     opacity: 1;
   }
 }


### PR DESCRIPTION
## Summary
- Delete button in spec-list now appears on `:focus-visible` — closes #52
- Table-editor row actions now appear on `:focus-within` — closes #51

Keyboard-only users can now see these controls when they tab to them. No visual changes for mouse users.

## Changes
- `spec-list.scss`: Added `&:focus-visible` selector to `.delete-btn`
- `table-editor.scss`: Added `tr:focus-within &` selector to `.row-actions`

## Test plan
- [x] Build passes (`ng build`)
- [ ] Tab to delete button in spec list — should become visible
- [ ] Tab to row actions in table editor — should become visible
- [ ] Hover behavior unchanged for mouse users

🤖 Generated with [Claude Code](https://claude.com/claude-code)