### PR TITLE
test: add unit tests for TableEditor, SectionNav, SpecPreview

### DIFF
--- a/src/app/components/section-nav/section-nav.spec.ts
+++ b/src/app/components/section-nav/section-nav.spec.ts
@@ -1,0 +1,120 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { SectionNavComponent } from './section-nav';
+import { type SpecSection } from '../../models/spec.model';
+
+@Component({
+  standalone: true,
+  imports: [SectionNavComponent],
+  template: `<app-section-nav
+    [sections]="sections()"
+    [activeIndex]="activeIndex()"
+    (selectIndex)="onSelect($event)"
+  />`,
+})
+class TestHostComponent {
+  sections = signal<SpecSection[]>([]);
+  activeIndex = signal(-1);
+  lastSelected: number | null = null;
+  onSelect(index: number): void {
+    this.lastSelected = index;
+  }
+}
+
+describe('SectionNavComponent', () => {
+  let host: TestHostComponent;
+  let fixture: ReturnType<typeof TestBed.createComponent<TestHostComponent>>;
+
+  const sampleSections: SpecSection[] = [
+    { heading: 'Purpose', level: 2, content: 'Purpose content' },
+    { heading: 'Public API', level: 2, content: 'API content' },
+    { heading: 'Exported Classes', level: 3, content: 'Classes' },
+  ];
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    host.sections.set(sampleSections);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(host).toBeTruthy();
+  });
+
+  it('should render Frontmatter as first nav item', () => {
+    const buttons = fixture.nativeElement.querySelectorAll('button.nav-item');
+    expect(buttons[0].textContent).toContain('Frontmatter');
+  });
+
+  it('should render all sections as nav items', () => {
+    const buttons = fixture.nativeElement.querySelectorAll('button.nav-item');
+    // Frontmatter + 3 sections = 4
+    expect(buttons.length).toBe(4);
+    expect(buttons[1].textContent).toContain('Purpose');
+    expect(buttons[2].textContent).toContain('Public API');
+    expect(buttons[3].textContent).toContain('Exported Classes');
+  });
+
+  it('should mark frontmatter as active when activeIndex is -1', () => {
+    host.activeIndex.set(-1);
+    fixture.detectChanges();
+    const buttons = fixture.nativeElement.querySelectorAll('button.nav-item');
+    expect(buttons[0].classList.contains('active')).toBe(true);
+    expect(buttons[1].classList.contains('active')).toBe(false);
+  });
+
+  it('should mark correct section as active', () => {
+    host.activeIndex.set(1);
+    fixture.detectChanges();
+    const buttons = fixture.nativeElement.querySelectorAll('button.nav-item');
+    expect(buttons[0].classList.contains('active')).toBe(false);
+    expect(buttons[2].classList.contains('active')).toBe(true); // index 1 = "Public API" = 3rd button
+  });
+
+  it('should emit -1 when frontmatter is clicked', () => {
+    const buttons = fixture.nativeElement.querySelectorAll('button.nav-item');
+    buttons[0].click();
+    expect(host.lastSelected).toBe(-1);
+  });
+
+  it('should emit section index when section is clicked', () => {
+    const buttons = fixture.nativeElement.querySelectorAll('button.nav-item');
+    buttons[2].click();
+    expect(host.lastSelected).toBe(1);
+  });
+
+  it('should apply level-3 class for deeply nested sections', () => {
+    const buttons = fixture.nativeElement.querySelectorAll('button.nav-item');
+    expect(buttons[3].classList.contains('level-3')).toBe(true);
+  });
+
+  it('should apply level-2 class for standard sections', () => {
+    const buttons = fixture.nativeElement.querySelectorAll('button.nav-item');
+    expect(buttons[1].classList.contains('level-2')).toBe(true);
+  });
+
+  it('should apply frontmatter class to frontmatter button', () => {
+    const buttons = fixture.nativeElement.querySelectorAll('button.nav-item');
+    expect(buttons[0].classList.contains('frontmatter')).toBe(true);
+  });
+
+  it('should update nav items when sections input changes', () => {
+    host.sections.set([{ heading: 'Only Section', level: 2, content: '' }]);
+    fixture.detectChanges();
+    const buttons = fixture.nativeElement.querySelectorAll('button.nav-item');
+    expect(buttons.length).toBe(2); // Frontmatter + 1 section
+    expect(buttons[1].textContent).toContain('Only Section');
+  });
+
+  it('should render with empty sections', () => {
+    host.sections.set([]);
+    fixture.detectChanges();
+    const buttons = fixture.nativeElement.querySelectorAll('button.nav-item');
+    expect(buttons.length).toBe(1); // Only Frontmatter
+  });
+});

--- a/src/app/components/spec-preview/spec-preview.spec.ts
+++ b/src/app/components/spec-preview/spec-preview.spec.ts
@@ -1,0 +1,172 @@
+import { Component, signal } from '@angular/core';
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { SpecPreviewComponent } from './spec-preview';
+import { type ValidationResult } from '../../models/spec.model';
+
+@Component({
+  standalone: true,
+  imports: [SpecPreviewComponent],
+  template: `<app-spec-preview [markdown]="markdown()" [validation]="validation()" />`,
+})
+class TestHostComponent {
+  markdown = signal('# Hello');
+  validation = signal<ValidationResult | null>(null);
+}
+
+describe('SpecPreviewComponent', () => {
+  let host: TestHostComponent;
+  let fixture: ReturnType<typeof TestBed.createComponent<TestHostComponent>>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(host).toBeTruthy();
+  });
+
+  it('should render markdown as HTML', async () => {
+    host.markdown.set('**bold text**');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const article = fixture.nativeElement.querySelector('.preview-content');
+    expect(article.innerHTML).toContain('<strong>bold text</strong>');
+  });
+
+  it('should render headings', async () => {
+    host.markdown.set('# Test Heading');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const article = fixture.nativeElement.querySelector('.preview-content');
+    expect(article.innerHTML).toContain('<h1');
+    expect(article.innerHTML).toContain('Test Heading');
+  });
+
+  it('should not show validation panel when validation is null', () => {
+    host.validation.set(null);
+    fixture.detectChanges();
+    const panel = fixture.nativeElement.querySelector('.validation-panel');
+    expect(panel).toBeFalsy();
+  });
+
+  it('should show valid badge when validation is valid', () => {
+    host.validation.set({ valid: true, errors: [] });
+    fixture.detectChanges();
+    const badge = fixture.nativeElement.querySelector('.status-badge.valid');
+    expect(badge).toBeTruthy();
+    expect(badge.textContent.trim()).toBe('Valid');
+  });
+
+  it('should show error count when validation has errors', () => {
+    host.validation.set({
+      valid: false,
+      errors: [
+        { level: 'error', field: 'module', message: 'Required' },
+        { level: 'error', field: 'version', message: 'Must be positive' },
+      ],
+    });
+    fixture.detectChanges();
+    const badge = fixture.nativeElement.querySelector('.status-badge.invalid');
+    expect(badge).toBeTruthy();
+    expect(badge.textContent.trim()).toBe('2 error(s)');
+  });
+
+  it('should show warning count alongside errors', () => {
+    host.validation.set({
+      valid: false,
+      errors: [
+        { level: 'error', field: 'module', message: 'Required' },
+        { level: 'warning', field: 'files', message: 'Consider adding files' },
+      ],
+    });
+    fixture.detectChanges();
+    const warningBadge = fixture.nativeElement.querySelector('.status-badge.warning');
+    expect(warningBadge).toBeTruthy();
+    expect(warningBadge.textContent.trim()).toBe('1 warning(s)');
+  });
+
+  it('should show warning count on valid spec with warnings', () => {
+    host.validation.set({
+      valid: true,
+      errors: [{ level: 'warning', field: 'depends_on', message: 'No dependencies listed' }],
+    });
+    fixture.detectChanges();
+    const warningBadge = fixture.nativeElement.querySelector('.status-badge.warning');
+    expect(warningBadge).toBeTruthy();
+    expect(warningBadge.textContent.trim()).toBe('1 warning(s)');
+  });
+
+  it('should list all validation issues', () => {
+    host.validation.set({
+      valid: false,
+      errors: [
+        { level: 'error', field: 'module', message: 'Required' },
+        { level: 'warning', field: 'files', message: 'Consider adding files' },
+      ],
+    });
+    fixture.detectChanges();
+    const items = fixture.nativeElement.querySelectorAll('.validation-list li');
+    expect(items.length).toBe(2);
+    expect(items[0].textContent).toContain('module');
+    expect(items[0].textContent).toContain('Required');
+    expect(items[1].textContent).toContain('files');
+  });
+
+  it('should apply error class to error items', () => {
+    host.validation.set({
+      valid: false,
+      errors: [{ level: 'error', field: 'module', message: 'Required' }],
+    });
+    fixture.detectChanges();
+    const item = fixture.nativeElement.querySelector('.validation-list li');
+    expect(item.classList.contains('error')).toBe(true);
+  });
+
+  it('should apply warning class to warning items', () => {
+    host.validation.set({
+      valid: true,
+      errors: [{ level: 'warning', field: 'files', message: 'Consider adding files' }],
+    });
+    fixture.detectChanges();
+    const item = fixture.nativeElement.querySelector('.validation-list li');
+    expect(item.classList.contains('warning')).toBe(true);
+  });
+
+  it('should not show validation list when valid with no warnings', () => {
+    host.validation.set({ valid: true, errors: [] });
+    fixture.detectChanges();
+    const list = fixture.nativeElement.querySelector('.validation-list');
+    expect(list).toBeFalsy();
+  });
+
+  it('should apply valid class to panel when valid', () => {
+    host.validation.set({ valid: true, errors: [] });
+    fixture.detectChanges();
+    const panel = fixture.nativeElement.querySelector('.validation-panel');
+    expect(panel.classList.contains('valid')).toBe(true);
+    expect(panel.classList.contains('invalid')).toBe(false);
+  });
+
+  it('should apply invalid class to panel when invalid', () => {
+    host.validation.set({
+      valid: false,
+      errors: [{ level: 'error', field: 'module', message: 'Required' }],
+    });
+    fixture.detectChanges();
+    const panel = fixture.nativeElement.querySelector('.validation-panel');
+    expect(panel.classList.contains('invalid')).toBe(true);
+    expect(panel.classList.contains('valid')).toBe(false);
+  });
+});

--- a/src/app/components/table-editor/table-editor.spec.ts
+++ b/src/app/components/table-editor/table-editor.spec.ts
@@ -1,0 +1,166 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { TableEditorComponent } from './table-editor';
+import { type MarkdownTable } from '../../models/markdown-table';
+
+@Component({
+  standalone: true,
+  imports: [TableEditorComponent],
+  template: `<app-table-editor [table]="table()" (tableChange)="onTableChange($event)" />`,
+})
+class TestHostComponent {
+  table = signal<MarkdownTable>({ headers: ['Name', 'Type'], rows: [['id', 'number']] });
+  lastEmitted: MarkdownTable | null = null;
+  onTableChange(t: MarkdownTable): void {
+    this.lastEmitted = t;
+  }
+}
+
+describe('TableEditorComponent', () => {
+  let host: TestHostComponent;
+  let fixture: ReturnType<typeof TestBed.createComponent<TestHostComponent>>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  function getComponent(): TableEditorComponent {
+    return fixture.debugElement.children[0].componentInstance as TableEditorComponent;
+  }
+
+  it('should create', () => {
+    expect(host).toBeTruthy();
+  });
+
+  it('should render headers as table column headers', () => {
+    const headers = fixture.nativeElement.querySelectorAll('th');
+    expect(headers[0].textContent.trim()).toBe('Name');
+    expect(headers[1].textContent.trim()).toBe('Type');
+  });
+
+  it('should render correct number of cell inputs', () => {
+    const inputs = fixture.nativeElement.querySelectorAll('input.cell-input');
+    expect(inputs.length).toBe(2);
+  });
+
+  describe('onCellChange', () => {
+    it('should emit new table with updated cell value', () => {
+      (getComponent() as any).onCellChange(0, 1, 'string');
+      expect(host.lastEmitted).toEqual({
+        headers: ['Name', 'Type'],
+        rows: [['id', 'string']],
+      });
+    });
+
+    it('should not mutate the original table', () => {
+      const original = host.table();
+      const originalRow = [...original.rows[0]];
+      (getComponent() as any).onCellChange(0, 0, 'changed');
+      expect(original.rows[0]).toEqual(originalRow);
+    });
+  });
+
+  describe('addRow', () => {
+    it('should emit table with new empty row appended', () => {
+      (getComponent() as any).addRow();
+      expect(host.lastEmitted).toEqual({
+        headers: ['Name', 'Type'],
+        rows: [['id', 'number'], ['', '']],
+      });
+    });
+
+    it('should create empty cells matching header count', () => {
+      host.table.set({ headers: ['A', 'B', 'C'], rows: [] });
+      fixture.detectChanges();
+      (getComponent() as any).addRow();
+      expect(host.lastEmitted!.rows[0]).toEqual(['', '', '']);
+    });
+  });
+
+  describe('removeRow', () => {
+    it('should emit table without the removed row', () => {
+      host.table.set({ headers: ['Name'], rows: [['a'], ['b'], ['c']] });
+      fixture.detectChanges();
+      (getComponent() as any).removeRow(1);
+      expect(host.lastEmitted).toEqual({
+        headers: ['Name'],
+        rows: [['a'], ['c']],
+      });
+    });
+  });
+
+  describe('moveRowUp', () => {
+    it('should swap row with the one above', () => {
+      host.table.set({ headers: ['Name'], rows: [['a'], ['b'], ['c']] });
+      fixture.detectChanges();
+      (getComponent() as any).moveRowUp(2);
+      expect(host.lastEmitted).toEqual({
+        headers: ['Name'],
+        rows: [['a'], ['c'], ['b']],
+      });
+    });
+
+    it('should be a no-op when row index is 0', () => {
+      host.table.set({ headers: ['Name'], rows: [['a'], ['b']] });
+      fixture.detectChanges();
+      (getComponent() as any).moveRowUp(0);
+      expect(host.lastEmitted).toBeNull();
+    });
+  });
+
+  describe('moveRowDown', () => {
+    it('should swap row with the one below', () => {
+      host.table.set({ headers: ['Name'], rows: [['a'], ['b'], ['c']] });
+      fixture.detectChanges();
+      (getComponent() as any).moveRowDown(0);
+      expect(host.lastEmitted).toEqual({
+        headers: ['Name'],
+        rows: [['b'], ['a'], ['c']],
+      });
+    });
+
+    it('should be a no-op when row is last', () => {
+      host.table.set({ headers: ['Name'], rows: [['a'], ['b']] });
+      fixture.detectChanges();
+      (getComponent() as any).moveRowDown(1);
+      expect(host.lastEmitted).toBeNull();
+    });
+  });
+
+  describe('empty state', () => {
+    it('should show empty state message when table has no rows', () => {
+      host.table.set({ headers: ['Name'], rows: [] });
+      fixture.detectChanges();
+      const emptyState = fixture.nativeElement.querySelector('.empty-state');
+      expect(emptyState).toBeTruthy();
+      expect(emptyState.textContent.trim()).toBe('No rows yet. Add one below.');
+    });
+
+    it('should not show empty state when table has rows', () => {
+      const emptyState = fixture.nativeElement.querySelector('.empty-state');
+      expect(emptyState).toBeFalsy();
+    });
+  });
+
+  describe('immutability', () => {
+    it('should preserve headers reference on row mutations', () => {
+      const originalHeaders = host.table().headers;
+      (getComponent() as any).addRow();
+      expect(host.lastEmitted!.headers).toBe(originalHeaders);
+    });
+
+    it('should create new row arrays on moveRowUp', () => {
+      host.table.set({ headers: ['Name'], rows: [['a'], ['b']] });
+      fixture.detectChanges();
+      const originalRows = host.table().rows;
+      (getComponent() as any).moveRowUp(1);
+      expect(host.lastEmitted!.rows).not.toBe(originalRows);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds **42 new unit tests** across 3 previously untested components
- **TableEditorComponent** (16 tests): cell editing, row CRUD, moveRowUp/Down edge cases, empty state rendering, immutability guarantees
- **SectionNavComponent** (12 tests): nav item rendering from sections input, active state tracking, click emission with correct indices, CSS level classes, dynamic updates
- **SpecPreviewComponent** (14 tests): markdown→HTML rendering via marked, validation panel states (valid/invalid/warnings), error/warning CSS classes, conditional list rendering

Total test count: 257 → 299

Contributes to #61

## Test plan

- [x] All 299 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)